### PR TITLE
Removed double urldecode

### DIFF
--- a/src/Fr/LS.php
+++ b/src/Fr/LS.php
@@ -506,7 +506,7 @@ HTML;
                  * Remember Me cookie is present. Decrypt its value
                  * to get the user ID who needs to be remembered
                  */
-                $rememberMeParts = explode(':|:', urldecode($rememberMe));
+                $rememberMeParts = explode(':|:', $rememberMe);
 
                 if (count($rememberMeParts) !== 2) {
                     $this->logout();


### PR DESCRIPTION
Fix for `Warning: openssl_decrypt(): IV passed is only 15 bytes long, cipher expects an IV of precisely 16 bytes`